### PR TITLE
Hover effect on Explore Courses Added

### DIFF
--- a/Components/LandingPage/HeroSection.tsx
+++ b/Components/LandingPage/HeroSection.tsx
@@ -74,7 +74,7 @@ const HeroSection = () => {
               />
               <div
                 onClick={() => router.push("/course")}
-                className="flex flex-row items-center gap-4 p-4 text-white bg-black border-2 border-black rounded-full h-fit cursor-pointer dark:bg-zinc-50"
+                className="flex flex-row items-center gap-4 p-4 text-white bg-black border-2 border-black rounded-full h-fit cursor-pointer dark:bg-zinc-50 ease-out hover:scale-110 duration-700"
               >
                 <span className="inline-flex bg-black "></span>
 


### PR DESCRIPTION
## Description 📝

<!-- NOTE: Remove the one which doesn't apply to your PR. If your PR is fixing something then remove `/Closes` -->
Fixes/Closes: #79 
Added the hover effect on the explore courses button

## Changes 💬

- Added the hover effect class of tailwind



## Screenshots (if applicable)

Include relevant screenshots or GIFs demonstrating the changes, especially for UI-related updates.
The size of the button become 1.1x in the 2nd pitcure when the cursor is place on it 
The cursor is not visible in the ss but it is placed
![Screenshot (22)](https://github.com/PiyushKalyanpy/GyanaGuru/assets/126336384/cc1b90da-f441-49a3-a997-08f81e6625cc)
![Screenshot (24)](https://github.com/PiyushKalyanpy/GyanaGuru/assets/126336384/fa98b09d-2877-4d82-bf60-bf7320bba5d1)

## Additional Notes 📒

The Explore courses button becomes 1.1x when the cursor is place on it

